### PR TITLE
Jonah justin/resolver

### DIFF
--- a/client/src/components/Demo/Demo.tsx
+++ b/client/src/components/Demo/Demo.tsx
@@ -182,13 +182,11 @@ function QueryDemo({
 
   function submitClientQuery() {
     const startTime = new Date().getTime();
-    //TODO edit this? clear server cache
     fetch('/api/clearCache').then((res) =>
       console.log('Cleared Server Cache!')
     );
     Quellify('/api/graphql', query, { maxDepth, maxCost, ipRate })
       .then((res) => {
-        // console.log(res);
         setVisualizerQuery(query);
         const responseTime: number = new Date().getTime() - startTime;
         addResponseTimes([...responseTimes, responseTime]);
@@ -213,7 +211,6 @@ function QueryDemo({
         fetch ('/api/queryTime').then(res => res.json())
         .then((time) => {
           if (setElapsed){
-            // console.log('time: ', time);
             setElapsed(time.time);
           }
         })

--- a/client/src/components/Visualizer/FlowTable.tsx
+++ b/client/src/components/Visualizer/FlowTable.tsx
@@ -23,11 +23,9 @@ const FlowTable: React.FC<Props> = ({ query, elapsed }) => {
   // The useEffect parse the query and generate the operation order
   useEffect(() => {
     const operation = parseQuery(query);
-    // if (operation) {
-      // setElapsedTime(elapsed);
+      setElapsedTime(elapsed);
       const operationOrder = generateOperationOrder(operation);
       setQueryOperations(operationOrder);
-    // }
   }, [elapsedTime]);
 
   // parses the query
@@ -56,10 +54,6 @@ const FlowTable: React.FC<Props> = ({ query, elapsed }) => {
     operation.selections.forEach((selection: { name: { value: any; }; selectionSet: OperationDefinitionNode | SelectionSetNode; }) => {
       if ('name' in selection) {
         let fieldName = parentName ? `${parentName}.${selection.name.value}` : selection.name.value;
-        // console.log('selection.name.value', selection.name.value);
-        // console.log('elapsedTime: ', elapsedTime);
-        // console.log('elapsedTime[selection.name.value]: ',elapsedTime[selection.name.value]);
-        // console.log('fieldName', fieldName);
         if (elapsedTime[selection.name.value] && operationOrder.length > 1) {
           const newName = fieldName + ` [resolved in ${elapsedTime[selection.name.value]}ms]`;
           operationOrder.push(newName);

--- a/client/src/components/Visualizer/Visualizer.modules.css
+++ b/client/src/components/Visualizer/Visualizer.modules.css
@@ -7,7 +7,7 @@
 }
 
 .flowTree {
-    height: 600px; 
+    min-height: 600px; 
     border: 3px solid lightGray;
     border-radius: 10px; 
     background:#474F57


### PR DESCRIPTION
- Previous version would render different primary fields in a query as separate trees stacked on top of each other. Fixed code to separate these trees along the x-axis.
- Cleaned out more clutter within the FlowTree component file